### PR TITLE
Fix for issue #27. Spyder-remote-client sends wrong prefix for location of the python

### DIFF
--- a/spyder-remote-client/spyder_remote_client/spyder/widgets.py
+++ b/spyder-remote-client/spyder_remote_client/spyder/widgets.py
@@ -226,4 +226,6 @@ class RemoteConsoleDialog(QDialog):
             for key, value in properties.items():
                 if key.startswith("conda_env_") and key.endswith("_yes"):
                     env_name = value.split("/")[-1]
-                    self.env_comvo.addItem(env_name, value)
+                    #Fix for issue #27 for the spyder-remote-server issue 
+                    prefix = '/home/'+properties["guest_account"]+'/'+env_name
+                    self.env_comvo.addItem(env_name, prefix)


### PR DESCRIPTION
## Description of Changes
Changed the prefix value which the spyder-remote-client sends to spyder-remote-server.
Before the changes, the prefix was:
/root/maxiconda/envs/maxiconda
After the changes, the prefix is:
/home/{user_name}/{conda_env}
Where  {user_name} and {conda_env} are taken from the spyder-remote-client GUI.
With the current hard settings, this is equivalent to :
/home/GUEST/maxiconda

<!--- Explain what you've done and why --->
When the spyder-remote-server receives "connect" command from the spyder-remote-client, he is trying to make a new python process {prefix/bin/python}. When the old prefix was /root/maxiconda/envs/maxiconda, we got permission error and the session hangs due exception and no return data to the client.

### Issue(s) Resolved

Fixes #27 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:
seimit
